### PR TITLE
Lock base role version to legacy

### DIFF
--- a/edms/requirements.yml
+++ b/edms/requirements.yml
@@ -1,2 +1,3 @@
 - src: coaxial.base
+  version: 1.2.1
 - src: coaxial.backup

--- a/healthchecks/requirements.yml
+++ b/healthchecks/requirements.yml
@@ -1,4 +1,5 @@
 - src: coaxial.base
+  version: 1.2.1
 - src: coaxial.docker-proxy
 - src: coaxial.healthchecks
 - src: geerlingguy.docker

--- a/mailserver/requirements.yml
+++ b/mailserver/requirements.yml
@@ -1,5 +1,6 @@
 - src: coaxial.raw-python
 - src: coaxial.base
+  version: 1.2.1
 - src: coaxial.mailcow
 - src: geerlingguy.docker
 - src: geerlingguy.pip

--- a/mainframe/requirements.yml
+++ b/mainframe/requirements.yml
@@ -1,6 +1,7 @@
 ---
 - src: https://github.com/coaxial/ansible-role-base.git
   name: coaxial.base
+  version: 1.2.1
 - src: https://github.com/coaxial/ansible-role-lxd.git
   name: coaxial.lxd
 - src: https://github.com/angstwad/docker.ubuntu

--- a/munin/requirements.yml
+++ b/munin/requirements.yml
@@ -1,1 +1,2 @@
-- coaxial.base
+- name: coaxial.base
+  version: 1.2.1

--- a/taskserver/requirements.yml
+++ b/taskserver/requirements.yml
@@ -1,6 +1,7 @@
 ---
 - src: coaxial.raw-python
 - src: coaxial.base
+  version: 1.2.1
 - src: coaxial.taskserver
 - src: geerlingguy.docker
 - src: geerlingguy.pip


### PR DESCRIPTION
v2.0.0 has potentially breaking changes to firewall rules, ensure legacy
version is pulled until I get around to upgrading each play.