### PR TITLE
Use bridge instead of macvlan

### DIFF
--- a/mainframe/tasks/lxd_profile.yml
+++ b/mainframe/tasks/lxd_profile.yml
@@ -26,6 +26,6 @@
         type: disk
       eth0:
         name: eth0
-        nictype: macvlan
+        nictype: bridged
         parent: br0
         type: nic


### PR DESCRIPTION
Lets containers talk to their host, useful for prometheus for example