### PR TITLE
Reduce backups size

### DIFF
--- a/edms/Makefile
+++ b/edms/Makefile
@@ -53,3 +53,7 @@ list-backups:
 	shred /tmp/tarsnap-key/tarsnap.key;\
 	sudo umount /tmp/tarsnap-key &&\
 	rmdir /tmp/tarsnap-key
+
+list-backups-with-size:
+	@# Must run the command on the target because it needs the cache dir
+	@ssh user@edms.lan "sudo tarsnap --print-stats -f '*'"

--- a/edms/templates/tarsnapper.yml.j2
+++ b/edms/templates/tarsnapper.yml.j2
@@ -10,7 +10,8 @@ jobs:
     sources:
       - /tmp/mayan.sql
       - {{ venv }}/mayan/media/document_storage
-      - {{ venv }}/mayan/media/document_cache
+      # Backing up the cache is optional, and it gets huge.
+      # - {{ venv }}/mayan/media/document_cache
       - {{ venv }}/mayan/settings
     exec_before: sudo -u postgres pg_dump mayan > /tmp/mayan.sql
     exec_after: rm /tmp/mayan.sql


### PR DESCRIPTION
Omit the document cache dir as it gets huge and is not needed for restoring. Also add a make target to check total backups size.